### PR TITLE
Change in regular expression definition and mkfs flag 

### DIFF
--- a/installer.sh
+++ b/installer.sh
@@ -167,7 +167,7 @@ disks(){
         read -p "> Root partition: " root_partition
         case "$filesystem" in
             1)
-                mkfs.ext4 -f "$root_partition"
+                mkfs.ext4 "$root_partition"
                 mount "$root_partition" /mnt
                 ;;
             2)

--- a/installer.sh
+++ b/installer.sh
@@ -353,7 +353,7 @@ arch_installer(){
 	# Setup user
 	arch-chroot /mnt /bin/bash -c "useradd -m -G wheel $user"
 	arch-chroot /mnt /bin/bash -c "(echo $user_password ; echo $user_password) | passwd $user"
-	arch-chroot /mnt sed -i 's/# %wheel ALL=(ALL) ALL/%wheel ALL=(ALL) ALL/' /etc/sudoers
+	arch-chroot /mnt sed -i 's/# %wheel ALL=(ALL\(:ALL\)*) ALL/%wheel ALL=(ALL\1) ALL/' /etc/sudoers
 	arch-chroot /mnt /bin/bash -c "xdg-user-dirs-update"
     # AUR installer
     clear


### PR DESCRIPTION
Hi, I would like to contribute the following changes: 
1. Extension of regular expression to identify `# $wheel ALL=(ALL:ALL) ALL` in addition to `# $wheel ALL=(ALL) ALL`. The first scenario was the case while installing Arch using the ISO  ARCH_202202, and without such permission the script wasn't able to install the Arch AUR helper, and everything afterwards failed. 
2. The flag -f is not a valid one for `mkfs.ext4` as implement in the Arch ISO. When using `-f` the terminal outputs `mkfs.ext4: invalid option -- 'f'`. When removed, the filesystem is created without any problem. 

Thanks a lot for the creation of the scripts! They work great as a tool to learn and customize my own Arch paradise, cheers